### PR TITLE
Use `macos` folder as source folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before using the dropDMG helper you need to set up DropDMG by doing the followin
 
 ## Configuring settings for the helper
 
-Now that DropDMG is set up you can to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, the `license name`, and the `volume name`. All of these settings are optional. If the `volume name` is empty then the executable name will be used, minus the `.app` extension.
+Now that DropDMG is set up you can to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, the `license name`, and the `volume name`. All of these settings are optional. If the `volume name` is empty then the application bundle name minus the `.app` extension will be used as the volume name.
 
 For a list of acceptable `format` values type `man dropdmg` in a Terminal window. 
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Before using the dropDMG helper you need to set up DropDMG by doing the followin
 
 ## Configuring settings for the helper
 
-Now that DropDMG is set up you can to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, the `license name`, and the `volume name`. All of these settings are optional.
+Now that DropDMG is set up you can to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, the `license name`, and the `volume name`. All of these settings are optional. If the `volume name` is empty then the executable name will be used, minus the `.app` extension.
 
 For a list of acceptable `format` values type `man dropdmg` in a Terminal window. 
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,11 @@ Before using the dropDMG helper you need to set up DropDMG by doing the followin
 
 ## Configuring settings for the helper
 
-Now that DropDMG is set up you need to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, and optionally the `license name` and `volume name`. For a list of acceptable `format` values type `man dropdmg` in a Terminal window. You can also provide the path to the `dropdmg` command line tool if for some reason you need to. This shouldn't be required though.
+Now that DropDMG is set up you can to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, the `license name`, and the `volume name`. All of these settings are optional.
 
-If `volume name` is empty then your application name will be used as the volume name.
+For a list of acceptable `format` values type `man dropdmg` in a Terminal window. 
+
+You can also provide the path to the `dropdmg` command line tool if for some reason you need to. This shouldn't be required though.
 
 ```
 # app.yml

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Before using the dropDMG helper you need to set up DropDMG by doing the followin
 
 ## Configuring settings for the helper
 
-Now that DropDMG is set up you need to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the layout name, and the license name. For a list of acceptable `format` values type `man dropdmg` in a Terminal window. You can also provide the path to the `dropdmg` command line tool if for some reason you need to. This shouldn't be required though.
+Now that DropDMG is set up you need to tell the helper the [format](https://c-command.com/dropdmg/manual#format) for the DMG file, the `layout name`, and optionally the `license name` and `volume name`. For a list of acceptable `format` values type `man dropdmg` in a Terminal window. You can also provide the path to the `dropdmg` command line tool if for some reason you need to. This shouldn't be required though.
+
+If `volume name` is empty then your application name will be used as the volume name.
 
 ```
 # app.yml
@@ -36,6 +38,7 @@ dropDMG:
   format: bzip2
   layout name: My App Layout
   license name: My App License
+  volume name: My App
   path: /usr/bin/local/dropdmg
 ```
 
@@ -60,3 +63,7 @@ build profiles:
 ```
 
 Note that `installer name` is a generic name intended to be shared by other helpers that work with installers. For example, the Auto Updater helper uses `installer name` as does the Inno Setup helper. If you want to use a different name for `macOS` then use the `macos` key rather than the `all platforms` key.
+
+## DropDMG variables
+
+DropDMG allows you to use the `APP_VERSION` and `APP_SHORT_VERSION_STRING` variables in text used in the layout.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,3 @@ build profiles:
 ```
 
 Note that `installer name` is a generic name intended to be shared by other helpers that work with installers. For example, the Auto Updater helper uses `installer name` as does the Inno Setup helper. If you want to use a different name for `macOS` then use the `macos` key rather than the `all platforms` key.
-
-## DropDMG variables
-
-DropDMG allows you to use the `APP_VERSION` and `APP_SHORT_VERSION_STRING` variables in text used in the layout.

--- a/dropDMG_packager.livecodescript
+++ b/dropDMG_packager.livecodescript
@@ -3,7 +3,7 @@ command packagingComplete pBuildProfile, pOutputFolder
 
   if the platform is not "macos" then return empty
 
-  local tSettingsA, tProfilesA, tName, tMacAppBundleFolder
+  local tSettingsA, tProfilesA, tName, tLayoutSourceFolder
 
   put levureAppGet("dropDMG", true) into tSettingsA
 
@@ -27,7 +27,7 @@ command packagingComplete pBuildProfile, pOutputFolder
   # Have a name so create DMG
   local tFile, tCmd, tResult, tReturnVal
 
-  put MacAppBundleFolder(pOutputFolder) into tMacAppBundleFolder
+  put DropDMGLayoutSourceFolder(pOutputFolder) into tLayoutSourceFolder
 
   put tName && levureAppGet("version") & "-" & levureAppGet("build") & ".dmg" into tFile
 
@@ -43,7 +43,7 @@ command packagingComplete pBuildProfile, pOutputFolder
   if tSettingsA["license name"] is not empty then
     put format(" --license-name=\"%s\"", tSettingsA["license name"]) after tCmd
   end if
-  put format(" --base-name=\"%s\" -o \"%s\" \"%s\"", tFile, pOutputFolder, tMacAppBundleFolder) after tCmd
+  put format(" --base-name=\"%s\" -o \"%s\" \"%s\"", tFile, pOutputFolder, tLayoutSourceFolder) after tCmd
   put shell(tCmd) into tResult
   put the result into tReturnVal
 
@@ -53,17 +53,6 @@ command packagingComplete pBuildProfile, pOutputFolder
 end packagingComplete
 
 
-private function MacAppBundleFolder pBuildFolder
-  local tMacFolder, tMacApp
-
-  put pBuildFolder & "/macos" into tMacFolder
-
-  put folders(tMacFolder) into tMacApp
-  filter tMacApp with "*.app"
-
-  if tMacApp is not empty then
-    return tMacFolder & "/" & tMacApp
-  else
-    return empty
-  end if
-end MacAppBundleFolder
+private function DropDMGLayoutSourceFolder pBuildFolder
+  return pBuildFolder & "/macos"
+end DropDMGLayoutSourceFolder

--- a/dropDMG_packager.livecodescript
+++ b/dropDMG_packager.livecodescript
@@ -25,15 +25,15 @@ command packagingComplete pBuildProfile, pOutputFolder
   if tName is empty then return empty
 
   # Have a name so create DMG
-  local tVolumeName, tFile, tCmd, tResult, tReturnVal
+  local tFile, tCmd, tResult, tReturnVal
 
-  put DropDMGVolumeName(pOutputFolder) into tVolumeName
   put DropDMGLayoutSourceFolder(pOutputFolder) into tLayoutSourceFolder
 
   put tName && levureAppGet("version") & "-" & levureAppGet("build") & ".dmg" into tFile
 
   if tSettingsA["path"] is empty then put "/usr/local/bin/dropdmg" into tSettingsA["path"]
   if tSettingsA["format"] is empty then put "bzip2" into tSettingsA["format"]
+  if tSettingsA["volume name"] is empty then put DropDMGVolumeName(pOutputFolder) into tSettingsA["volume name"]
 
   # Create DMG using DropDMG
   put format("\"%s\" --format=\"%s\"", tSettingsA["path"], tSettingsA["format"]) into tCmd
@@ -44,7 +44,8 @@ command packagingComplete pBuildProfile, pOutputFolder
   if tSettingsA["license name"] is not empty then
     put format(" --license-name=\"%s\"", tSettingsA["license name"]) after tCmd
   end if
-  put format(" --volume-name=\"%s\" --base-name=\"%s\" -o \"%s\" \"%s\"", tVolumeName, tFile, pOutputFolder, tLayoutSourceFolder) after tCmd
+
+  put format(" --volume-name=\"%s\" --base-name=\"%s\" -o \"%s\" \"%s\"", tSettingsA["volume name"], tFile, pOutputFolder, tLayoutSourceFolder) after tCmd
   put shell(tCmd) into tResult
   put the result into tReturnVal
 

--- a/dropDMG_packager.livecodescript
+++ b/dropDMG_packager.livecodescript
@@ -25,8 +25,9 @@ command packagingComplete pBuildProfile, pOutputFolder
   if tName is empty then return empty
 
   # Have a name so create DMG
-  local tFile, tCmd, tResult, tReturnVal
+  local tVolumeName, tFile, tCmd, tResult, tReturnVal
 
+  put DropDMGVolumeName(pOutputFolder) into tVolumeName
   put DropDMGLayoutSourceFolder(pOutputFolder) into tLayoutSourceFolder
 
   put tName && levureAppGet("version") & "-" & levureAppGet("build") & ".dmg" into tFile
@@ -43,7 +44,7 @@ command packagingComplete pBuildProfile, pOutputFolder
   if tSettingsA["license name"] is not empty then
     put format(" --license-name=\"%s\"", tSettingsA["license name"]) after tCmd
   end if
-  put format(" --base-name=\"%s\" -o \"%s\" \"%s\"", tFile, pOutputFolder, tLayoutSourceFolder) after tCmd
+  put format(" --volume-name=\"%s\" --base-name=\"%s\" -o \"%s\" \"%s\"", tVolumeName, tFile, pOutputFolder, tLayoutSourceFolder) after tCmd
   put shell(tCmd) into tResult
   put the result into tReturnVal
 
@@ -56,3 +57,20 @@ end packagingComplete
 private function DropDMGLayoutSourceFolder pBuildFolder
   return pBuildFolder & "/macos"
 end DropDMGLayoutSourceFolder
+
+
+private function DropDMGVolumeName pBuildFolder
+  local tMacFolder, tMacApp
+
+  put pBuildFolder & "/macos" into tMacFolder
+
+  put folders(tMacFolder) into tMacApp
+  filter tMacApp with "*.app"
+
+  if tMacApp is not empty then
+    set the itemdelimiter to "."
+    return item 1 to -2 of tMacApp
+  else
+    return empty
+  end if
+end DropDMGVolumeName


### PR DESCRIPTION
When calling the dropDMG command line tool the `macos` folder is now the source. Previously it was the application bundle inside of the `macos` folder. 

In addition, a `volume name` setting has been added. If not set then the application bundle name minus the `.app` extension will be used as the volume name.